### PR TITLE
修复swagger array子类型为基础类型时schema显示为空的问题

### DIFF
--- a/swagger-bootstrap-ui/src/main/resources/webjars/bycdao-ui/cdao/swaggerbootstrapui.js
+++ b/swagger-bootstrap-ui/src/main/resources/webjars/bycdao-ui/cdao/swaggerbootstrapui.js
@@ -3921,16 +3921,20 @@
                         if (schemaType=="array"){
                             minfo.type=schemaType;
                             var schItem=schemaObject["items"];
-                            var ref=schItem["$ref"];
-                            var className=$.getClassName(ref);
-                            minfo.schemaValue=className;
-                            var def=that.getDefinitionByName(className);
-                            if(def!=null){
-                                minfo.def=def;
-                                minfo.value=def.value;
-                                if(def.description!=undefined&&def.description!=null&&def.description!=""){
-                                    minfo.description=$.replaceMultipLineStr(def.description);
+                            if(schItem.hasOwnProperty("$ref")){
+                                var ref=schItem["$ref"];
+                                var className=$.getClassName(ref);
+                                minfo.schemaValue=className;
+                                var def=that.getDefinitionByName(className);
+                                if(def!=null){
+                                    minfo.def=def;
+                                    minfo.value=def.value;
+                                    if(def.description!=undefined&&def.description!=null&&def.description!=""){
+                                        minfo.description=$.replaceMultipLineStr(def.description);
+                                    }
                                 }
+                            } else{
+                                minfo.schemaValue = schItem["type"]
                             }
                         }else{
                             if (schemaObject.hasOwnProperty("$ref")){


### PR DESCRIPTION
修复Array类型时,如果子类为基础类型 schema则显示改基础类型,方便阅读使用.