### PR TITLE
解决地址显示的BUG, 确保请求能够正确发送出去

### DIFF
--- a/swagger-bootstrap-ui/src/main/resources/webjars/bycdao-ui/cdao/swaggerbootstrapui.js
+++ b/swagger-bootstrap-ui/src/main/resources/webjars/bycdao-ui/cdao/swaggerbootstrapui.js
@@ -4966,7 +4966,7 @@
         //截取字符串
         var newurl=newfullPath.substring(newfullPath.indexOf("/"));
         //that.log("新的url:"+newurl)
-        newurl=newurl.replace("//","/");
+        newurl = newurl.replace("//","/");
         //判断应用实例的baseurl
         if(that.currentInstance.baseUrl!=""&&that.currentInstance.baseUrl!="/"){
             newurl=that.currentInstance.baseUrl+newurl;
@@ -4974,8 +4974,9 @@
         var startApiTime=new Date().getTime();
         swpinfo.showUrl=newurl;
         //swpinfo.id="ApiInfo"+Math.round(Math.random()*1000000);
-        swpinfo.url=newurl;
-        swpinfo.originalUrl=newurl;
+        var urlForRealUsage=newurl.replace(/^([^{]+).*$/g, '$1');
+        swpinfo.url=urlForRealUsage;
+        swpinfo.originalUrl=urlForRealUsage;
         swpinfo.basePathFlag=basePathFlag;
         swpinfo.methodType=mtype.toUpperCase();
         //接口id使用MD5策略,缓存整个调试参数到localStorage对象中,供二次调用


### PR DESCRIPTION
在Spring当中，如果使用了如下的API描述：
@RequestMapping(method = RequestMethod.POST, params = "action=crawl")
    public GenericResponse<Boolean> crawl(
        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end) 

则在Swagger当中会产生以下的API地址：
/api/v1/wms/orders?action=crawl{&end,start}

这种地址在bootstrap-ui当中测试时，没有办法正确发出请求，尝试修改URL地址达到正确发送请求的目的。
