### PR TITLE
add response content incloud data:image/jpg;base64 show picture pervi…

### DIFF
--- a/knife4j-front/cdao/swaggerbootstrapui.js
+++ b/knife4j-front/cdao/swaggerbootstrapui.js
@@ -3061,6 +3061,14 @@
                 aceValue=JSON.stringify(xhr["responseJSON"],null,2);
                 //that.log(JSON.stringify(xhr["responseJSON"],null,2))
                 //jsondiv.html(JSON.stringify(xhr["responseJSON"],null,2));
+                // 如果返回的json中包含 data:image/jpg;base64 ， 说明返回的是图片，这个时候需要显示图片
+                if(aceValue.indexOf("data:image/jpg;base64") > -1) {
+                    $("#perviewTab"+apiKeyId).css('display', 'block');
+                    $("#perview"+apiKeyId).css('display', 'block');
+                    let newStr = aceValue.substring(aceValue.indexOf("data:image/jpg;base64"));
+                    $("#perview"+apiKeyId).html('<img src="'+ newStr.substring(0, newStr.indexOf("\",")) +'">');
+                    $("#perview"+apiKeyId).css('height', '300px');
+                }
             }else{
                 aceValue=JSON.stringify(data,null,2);
                 //针对表单提交,error的情况,会产生data

--- a/knife4j-front/doc.html
+++ b/knife4j-front/doc.html
@@ -781,6 +781,7 @@
                 <li>Raw</li>
                 <li>Headers</li>
                 <li>Curl</li>
+                <li id="perviewTab{{id}}" style="display: none">图片预览</li>
             </ul>
             <div class="layui-tab-content" id="layuiresponsecontentmain{{id}}" style="height: 100px;
     margin-top: 0px;left: 0px;position: absolute;width: 98%;margin-left: 10px;">
@@ -788,6 +789,7 @@
                 <div class="layui-tab-item" id="respraw{{id}}"></div>
                 <div class="layui-tab-item" id="respheaders{{id}}"></div>
                 <div class="layui-tab-item" id="respcurl{{id}}"></div>
+                <div class="layui-tab-item" id="perview{{id}}" style="display: none"></div>
             </div>
             <div style="right: 30px;position: absolute;margin-top: 8px;z-index: 9999;" id="responsestatus{{id}}"><span class="debug-span-label">响应码:</span><span class="debug-span-value">200 OK</span>  &nbsp;&nbsp;&nbsp;&nbsp;<span class="debug-span-label">耗时:</span><span class="debug-span-value">161 ms</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="debug-span-label">大小:</span><span class="debug-span-value">120 b</span></div>
         </div>


### PR DESCRIPTION
add response content incloud data:image/jpg;base64 show picture perview, example verify code

添加了在返回的响应内容的tab页，增加一个图片预览，在检测到返回json数据里面包含data:image/jpg;base64字符串时，可以预览图片，我们在开发过程中，对显示后端返回的验证码，调试接口非常有帮助