### PR TITLE
Migrate to new Spring Boot auto configuration introduced in Spring Boot OSS 3.0.0-M5

### DIFF
--- a/knife4j/knife4j-aggregation-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.xiaoymin.knife4j.aggre.spring.configuration.Knife4jAggregationAutoConfiguration

--- a/knife4j/knife4j-openapi2-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.xiaoymin.knife4j.spring.configuration.Knife4jAutoConfiguration

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.xiaoymin.knife4j.spring.configuration.Knife4jAutoConfiguration


### PR DESCRIPTION
Fixes #490.

Changes proposed in this pull request:
  - Migrate to new Spring Boot auto configuration introduced in Spring Boot OSS 3.0.0-M5