### PR TITLE
Cloud模式，servicePath补充‘/’前缀，逻辑调整

### DIFF
--- a/knife4j/knife4j-aggregation-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/core/pojo/SwaggerRoute.java
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/core/pojo/SwaggerRoute.java
@@ -118,7 +118,7 @@ public class SwaggerRoute {
             }
             if (StrUtil.isNotBlank(cloudRoute.getServicePath())&&!StrUtil.equals(cloudRoute.getServicePath(), RouteDispatcher.ROUTE_BASE_PATH)){
                 //判断是否是/开头
-                if (!StrUtil.startWith(cloudRoute.getServicePath(),RouteDispatcher.ROUTE_BASE_PATH)){
+                if (!StrUtil.startWithAny(cloudRoute.getServicePath(),RouteDispatcher.ROUTE_BASE_PATH,"http://","https://")){
                     this.servicePath= RouteDispatcher.ROUTE_BASE_PATH+cloudRoute.getServicePath();
                 }else{
                     this.servicePath=cloudRoute.getServicePath();


### PR DESCRIPTION
文档不一定集成在网关，单独建立文档服务时，根据Cloud配置创建文档的来源可能是各种不同的域名来源的文档，有时候希望展示完整的url地址
之前代码在servicePath以http、https开头时会在前面加‘/’,不太友好
调整后，当servicePath以http、https开头时，不再servicePath前补充‘/’。