### PR TITLE
增加Spring Security注解展示支持

### DIFF
--- a/knife4j-doc/docs/features/springSecurity.md
+++ b/knife4j-doc/docs/features/springSecurity.md
@@ -1,0 +1,35 @@
+# 3.30 Spring Security注解
+
+:::caution 温馨提醒
+增强功能需要通过配置yml配置文件开启增强,自4.0.0开始
+```yml
+knife4j:
+  enable: true
+```
+:::
+
+`Knife4j`为了满足`权限验证`将Spring Security的`PostAuthorize`、`PostFilter`、`PreAuthorize`、`PreFilter`的注解信息追加到接口描述中
+
+
+代码展示
+```java
+@RestController
+@RequestMapping("/hello")
+@PostAuthorize("hasAuthority('class')")
+@PostFilter("hasAuthority('class')")
+@PreAuthorize("hasAuthority('class')")
+@PreFilter("hasAuthority('class')")
+public class HelloController {
+
+    @GetMapping("/security")
+    @PostAuthorize("hasAuthority('method')")
+    @PostFilter("hasAuthority('method')")
+    @PreAuthorize("hasAuthority('method')")
+    @PreFilter("hasAuthority('method')")
+    @ApiOperation(value = "", notes = "Spring Security注解追加到接口描述")
+    public String security() {
+        return "hello security";
+    }
+}
+```
+

--- a/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
@@ -97,6 +97,14 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <version>${knife4j-spring-boot.version}</version>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
 

--- a/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/plugin/SecurityAnnotationPlugin.java
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/plugin/SecurityAnnotationPlugin.java
@@ -1,0 +1,89 @@
+package com.github.xiaoymin.knife4j.spring.plugin;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.access.prepost.PreFilter;
+import org.springframework.stereotype.Component;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.OperationContext;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * 接口描述追加Spring Security注解信息
+ *
+ * @since  4.0.0
+ * @author changjin wei(魏昌进)
+ * @see org.springframework.security.access.prepost.PostAuthorize
+ * @see org.springframework.security.access.prepost.PostFilter
+ * @see org.springframework.security.access.prepost.PreAuthorize
+ * @see org.springframework.security.access.prepost.PreFilter
+ * 2022/12/27
+ */
+@Component
+@ConditionalOnClass(name = "org.springframework.security.access.prepost.PostAuthorize")
+@Order(Ordered.HIGHEST_PRECEDENCE + 200)
+public class SecurityAnnotationPlugin extends AbstractOperationBuilderPlugin {
+
+    private static final String PACKAGE_PREFIX = "org.springframework.security.access.prepost.";
+
+    @Override
+    public void apply(OperationContext context) {
+        String notes = context.operationBuilder().build().getNotes();
+        StringBuffer notesBuffer = new StringBuffer(notes == null ? "" : notes);
+        appendClassAnnotationNote(notesBuffer, context);
+        appendMethodAnnotationNote(notesBuffer, context);
+        context.operationBuilder().notes(notesBuffer.toString());
+    }
+
+
+    @Override
+    public boolean supports(DocumentationType delimiter) {
+        return true;
+    }
+
+    private void appendClassAnnotationNote(StringBuffer notesBuffer, OperationContext context) {
+        StringBuffer securityNotes = new StringBuffer();
+        context.findControllerAnnotation(PostAuthorize.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        context.findControllerAnnotation(PostFilter.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        context.findControllerAnnotation(PreAuthorize.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        context.findControllerAnnotation(PreFilter.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        if (securityNotes.length() > 0) {
+            notesBuffer.append("<p />");
+            notesBuffer.append("class: ");
+            notesBuffer.append(securityNotes);
+        }
+    }
+
+    private void appendMethodAnnotationNote(StringBuffer notesBuffer, OperationContext context) {
+        StringBuffer securityNotes = new StringBuffer();
+        context.findAnnotation(PostAuthorize.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        context.findAnnotation(PostFilter.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        context.findAnnotation(PreAuthorize.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        context.findAnnotation(PreFilter.class)
+               .ifPresent(ann -> append(securityNotes, ann));
+        if (securityNotes.length() > 0) {
+            notesBuffer.append("<p />");
+            notesBuffer.append("method: ");
+            notesBuffer.append(securityNotes);
+        }
+    }
+
+    private void append(StringBuffer securityNotes, Annotation ann) {
+        String txt = ann.toString().replace(PACKAGE_PREFIX, "").replace("\\'", "'");
+        securityNotes.append(txt)
+                     .append(" ");
+    }
+
+}


### PR DESCRIPTION
增加Spring Security展示支持

代码展示
```java
@RestController
@RequestMapping("/hello")
@PostAuthorize("hasAuthority('class')")
@PostFilter("hasAuthority('class')")
@PreAuthorize("hasAuthority('class')")
@PreFilter("hasAuthority('class')")
public class HelloController {

    @GetMapping("/security")
    @PostAuthorize("hasAuthority('method')")
    @PostFilter("hasAuthority('method')")
    @PreAuthorize("hasAuthority('method')")
    @PreFilter("hasAuthority('method')")
    @ApiOperation(value = "", notes = "Spring Security注解追加到接口描述")
    public String security() {
        return "hello security";
    }
}
```

效果预览
![image](https://user-images.githubusercontent.com/30821411/209750646-9e4cd342-216d-4492-8e15-2093582c5255.png)
