### PR TITLE
新增对OAS2 response allOf 支持

### DIFF
--- a/knife4j-vue/vue.config.js
+++ b/knife4j-vue/vue.config.js
@@ -5,6 +5,9 @@ const CompressionWebpackPlugin = require('compression-webpack-plugin');
 const CopyWebPackPlugin = require('copy-webpack-plugin');
 const productionGzipExtensions = ["js", "css"];
 module.exports = {
+  transpileDependencies: [
+    /[/\\]node_modules[/\\](.+?)?mermaid(.*)/
+  ],
   publicPath: ".",
   assetsDir: "webjars",
   outputDir: "dist",


### PR DESCRIPTION
新增了对 OAS2 response allOf 属性的解析功能，更好地和其他文档工具集成如 golang swaggo

思路是在需要时构建新的Model

经测试可以和原有功能正常集成，目前在我的项目上运行良好：
![image](https://github.com/xiaoymin/knife4j/assets/63706387/a29c10c7-f767-48c7-8ad9-4c89a0bcce84)
