### PR TITLE
bugfix: 多个服务的order默认值为0,此时会丢失服务.

### DIFF
--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/discover/ServiceDiscoverHandler.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/discover/ServiceDiscoverHandler.java
@@ -115,7 +115,7 @@ public class ServiceDiscoverHandler implements EnvironmentAware {
         Set<String> excludeService = getExcludeService(service);
         // 个性化服务的配置信息
         Map<String, Knife4jGatewayProperties.ServiceConfigInfo> configInfoMap = this.knife4jGatewayProperties.getDiscover().getServiceConfig();
-        Set<OpenAPI2Resource> resources = new TreeSet<>(Comparator.comparing(OpenAPI2Resource::getOrder));
+        Set<OpenAPI2Resource> resources = new TreeSet<>();
         // 获取路由定义，并解析
         gatewayProperties.getRoutes()
                 .stream()


### PR DESCRIPTION
多个服务的order默认值为0,TreeSet的特性造成容器内的服务丢失.
由于OpenAPI2Resource已经实现了order+name排序,所以直接用即可.