### PR TITLE
新功能: 适配Spring Authorization Server

### DIFF
--- a/knife4j-vue/public/oauth/oauth2.html
+++ b/knife4j-vue/public/oauth/oauth2.html
@@ -69,8 +69,6 @@
             "grant_type":"authorization_code",
             "code":this.code,
             "redirect_uri":decodeURIComponent(this.cacheValue.redirectUri),
-            "client_id":this.cacheValue.clientId,
-            "client_secret":this.cacheValue.clientSecret
         }
         let instance=axios.create();
         let requestConfig={
@@ -79,7 +77,7 @@
             timeout: 0,
             //此data必传,不然默认是data:undefined,https://github.com/axios/axios/issues/86
             //否则axios会忽略请求头Content-Type
-            data: null,
+            data: `client_id=${this.cacheValue.clientId}&client_secret=${this.cacheValue.clientSecret}`,
             params:params
         }
         instance.request(requestConfig).then(res=>{

--- a/knife4j/knife4j-openapi3-ui/src/main/resources/webjars/oauth/oauth2.html
+++ b/knife4j/knife4j-openapi3-ui/src/main/resources/webjars/oauth/oauth2.html
@@ -69,8 +69,6 @@
             "grant_type":"authorization_code",
             "code":this.code,
             "redirect_uri":decodeURIComponent(this.cacheValue.redirectUri),
-            "client_id":this.cacheValue.clientId,
-            "client_secret":this.cacheValue.clientSecret
         }
         let instance=axios.create();
         let requestConfig={
@@ -79,7 +77,7 @@
             timeout: 0,
             //此data必传,不然默认是data:undefined,https://github.com/axios/axios/issues/86
             //否则axios会忽略请求头Content-Type
-            data: null,
+            data: `client_id=${this.cacheValue.clientId}&client_secret=${this.cacheValue.clientSecret}`,
             params:params
         }
         instance.request(requestConfig).then(res=>{


### PR DESCRIPTION
## 起因

在使用 Spring Authorization Server 1.0.4 作为认证授权服务时, 使用授权码模式请求 Token 端点时, 会做如下校验:

1. 路径参数中不允许存在`client_id`
2. 路径参数中不允许存在`client_secret`

所以 Token 端点请求会抛出非法请求异常, 导致无法获取到令牌

## 解决方案

在`/oauth/oauth2.html`页面中, 将`client_id`和`client_secret`参数调整至`form-data`中

通过测试即可进行访问

## 其它说明

因`spring-security-oauth`已不再维护, 所以没有进行论证测试