### PR TITLE
fix: 修复vue3模块无法使用script的问题

### DIFF
--- a/knife4j-vue3/package.json
+++ b/knife4j-vue3/package.json
@@ -44,6 +44,7 @@
     "unplugin-vue-components": "^0.25.1",
     "vite": "^4.3.9",
     "vite-plugin-compression": "^0.5.1",
+    "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-remove-console": "^2.1.1"
   }
 }

--- a/knife4j-vue3/src/views/api/index.vue
+++ b/knife4j-vue3/src/views/api/index.vue
@@ -20,10 +20,9 @@
           </template>
           <OpenApi :api="api" :swaggerInstance="swaggerInstance" />
         </a-tab-pane>
-        <!-- TODO 暂时不知道vite怎么支持 -->
-<!--        <a-tab-pane v-if="settings.enableOpenApi" key="script" tab="Script">-->
-<!--          <ScriptView :api="api" :swaggerInstance="swaggerInstance" />-->
-<!--        </a-tab-pane>-->
+        <a-tab-pane v-if="settings.enableOpenApi" key="script" tab="Script">-->
+          <ScriptView :api="api" :swaggerInstance="swaggerInstance" />-->
+        </a-tab-pane>-->
 
       </a-tabs>
     </a-row>
@@ -48,7 +47,7 @@ export default {
     "Document": defineAsyncComponent(() => import("./Document.vue")),
     "Debug": defineAsyncComponent(() => import("./Debug.vue")),
     "OpenApi": defineAsyncComponent(() => import("./OpenApi.vue")),
-    // "ScriptView": defineAsyncComponent(() => import("./ScriptView.vue")),
+    "ScriptView": defineAsyncComponent(() => import("./ScriptView.vue")),
     FileTextOutlined,
   },
   props: {

--- a/knife4j-vue3/vite.config.js
+++ b/knife4j-vue3/vite.config.js
@@ -6,6 +6,7 @@ import { AntDesignVueResolver } from 'unplugin-vue-components/resolvers'
 import viteCompression from 'vite-plugin-compression';
 import removeConsole from 'vite-plugin-remove-console';
 import { resolve } from 'path'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -16,6 +17,7 @@ export default defineConfig({
     Components({
       resolvers: [AntDesignVueResolver()]
     }),
+    nodePolyfills(),
     viteCompression({
       deleteOriginFile: false, //删除源文件
       threshold: 10240, //压缩前最小文件大小


### PR DESCRIPTION
使用vite-plugin-node-polyfills插件修复了vue3版本下script无法正常使用的问题