### PR TITLE
修复变量名错误：peration -> operation

### DIFF
--- a/knife4j-doc/docs/blog/add-authorization-header.mdx
+++ b/knife4j-doc/docs/blog/add-authorization-header.mdx
@@ -183,7 +183,7 @@ public GlobalOpenApiCustomizer orderGlobalOpenApiCustomizer() {
             openApi.getPaths().forEach((s, pathItem) -> {
                 // 为所有接口添加鉴权
                 pathItem.readOperations().forEach(operation -> {
-                    peration.addSecurityItem(new SecurityRequirement().addList(HttpHeaders.AUTHORIZATION));
+                    operation.addSecurityItem(new SecurityRequirement().addList(HttpHeaders.AUTHORIZATION));
                 });
             });
         }


### PR DESCRIPTION
在 [OpenAPI3规范中添加Authorization鉴权请求Header不生效？](https://doc.xiaominfo.com/docs/blog/add-authorization-header) 文章中 GlobalOpenApiCustomizer 中的变量名称使用错误，应从 `peration` 改为 `operation`！