### PR TITLE
删除markdown中存在重复的“请求参数”字样

### DIFF
--- a/knife4j-vue/src/components/officeDocument/markdownSingleTransform.js
+++ b/knife4j-vue/src/components/officeDocument/markdownSingleTransform.js
@@ -56,8 +56,6 @@ function createApiRequestParameters(apiInfo, markdownCollections) {
   let reqParameters = apiInfo.reqParameters;
   markdownLines(markdownCollections);
   markdownCollections.push('**请求参数**:');
-  markdownLines(markdownCollections);
-  markdownCollections.push('**请求参数**:');
   // 判断是否拥有请求参数
   if (reqParameters.length > 0) {
     markdownLines(markdownCollections);


### PR DESCRIPTION
点击“复制文档”后，生成的markdown中会存在2行同样的“请求参数”，需要手工进行清除， 不方便。

本次修改删除了markdown文档中重复的“请求参数”字样。