### PR TITLE
fix(openapi): wrap schema definitions in components.schemas for OpenAPI 3.0

### DIFF
--- a/knife4j-vue/src/core/Knife4jAsync.js
+++ b/knife4j-vue/src/core/Knife4jAsync.js
@@ -5270,7 +5270,7 @@ SwaggerBootstrapUi.prototype.readOpenApiSpeci = function (path, swpinfo, apiInfo
       copyOpenApi['definitions'] = def;
     } else {
       def = this.readOpenApiSpeciOAS3(apiInfo, swaggerData);
-      copyOpenApi['components'] = def;
+      copyOpenApi['components'] = { schemas: def };
     }
     swpinfo.openApiRaw = copyOpenApi;
     // 查询definitions节点

--- a/knife4j-vue3/src/core/Knife4jAsync.js
+++ b/knife4j-vue3/src/core/Knife4jAsync.js
@@ -5021,7 +5021,7 @@ SwaggerBootstrapUi.prototype.readOpenApiSpeci = function (path, swpinfo, apiInfo
       copyOpenApi['definitions'] = def;
     } else {
       def = this.readOpenApiSpeciOAS3(apiInfo, swaggerData);
-      copyOpenApi['components'] = def;
+      copyOpenApi['components'] = { schemas: def };
     }
     swpinfo.openApiRaw = copyOpenApi;
     // 查询definitions节点


### PR DESCRIPTION
### Changes：Fix issue ：https://github.com/xiaoymin/knife4j/issues/920
fix(openapi): wrap schema definitions in components.schemas for OpenAPI 3.0 compliance

- Change components assignment from direct definition to { schemas: def } to match OpenAPI 3.0 specification in both Vue 2 and Vue 3 implementations.