### PR TITLE
fix:修复requestBody为基本类型的问题 #894

### DIFF
--- a/knife4j-vue/src/core/Knife4jAsync.js
+++ b/knife4j-vue/src/core/Knife4jAsync.js
@@ -2384,9 +2384,9 @@ SwaggerBootstrapUi.prototype.getSwaggerModelRefType = function (propobj, oas2) {
               refType = RegExp.$1;
             }
           }
-        } else {
-          refType = type;
         }
+      } else {
+        refType = type;
       }
     } else {
       if (type == 'array') {


### PR DESCRIPTION
修复 当requestBody为基本类型时requestContentType为x-www-form-urlencoded
#894