### PR TITLE
feat: support custom doc scripts

### DIFF
--- a/knife4j-doc/docs/features/customScript.md
+++ b/knife4j-doc/docs/features/customScript.md
@@ -1,0 +1,57 @@
+# 3.19 自定义脚本
+
+`customJavaScriptUrls` 用于在 `doc.html` 页面加载开发者自己托管的 JavaScript 脚本。脚本加载后可以通过 `window.Knife4j.registerRequestInterceptor` 注册请求前拦截器，在调试请求发出前修改请求配置。
+
+## 开启配置
+
+```yaml
+knife4j:
+  setting:
+    customJavaScriptUrls:
+      - /knife4j/custom/request-id.js
+```
+
+`customJavaScriptUrls` 支持配置多个脚本地址，Knife4j 会按配置顺序加载。空地址会被忽略，相同地址只加载一次。脚本加载失败时只在浏览器控制台输出警告，不会阻断 `doc.html` 页面和调试功能。
+
+## 注入调试请求头
+
+例如在应用中提供 `/knife4j/custom/request-id.js`：
+
+```js
+window.Knife4j.registerRequestInterceptor(function(config, context) {
+  config.headers = config.headers || {};
+  config.headers["x-request-id"] = Date.now().toString();
+  return config;
+});
+```
+
+注册后，开发者在 `doc.html` 页面发起 Raw、Form、x-www-form-urlencoded 三种调试请求时，请求头都会自动带上 `x-request-id`，页面展示的 curl 内容也会包含最终注入的请求头。
+
+## 拦截器参数
+
+`registerRequestInterceptor` 接收一个同步函数：
+
+```js
+window.Knife4j.registerRequestInterceptor(function(config, context) {
+  return config;
+});
+```
+
+- `config`：本次调试请求的 axios request config。
+- `context.api`：当前接口信息。
+- `context.swaggerInstance`：当前文档分组实例。
+- `context.requestType`：当前请求类型，取值为 `raw`、`form`、`urlForm`。
+- `context.settings`：当前 Knife4j 个性化配置。
+- `context.headers`：本次请求初始请求头。
+
+如果某个拦截器抛出异常，Knife4j 会捕获异常并继续执行调试请求，避免自定义脚本影响主流程。
+
+## 与 AfterScript 的区别
+
+`AfterScript` 是单个接口调试响应成功后执行的脚本，适合处理响应结果。
+
+自定义脚本是页面级扩展能力，脚本会在 `doc.html` 初始化配置后加载，适合注册请求前拦截器，例如统一追加请求头、按分组补充调试参数等。
+
+## 安全说明
+
+自定义脚本会在 `doc.html` 页面内执行，权限等同页面脚本。请只配置可信来源，并由应用自行托管和审查脚本内容。

--- a/knife4j-doc/sidebars.js
+++ b/knife4j-doc/sidebars.js
@@ -89,6 +89,7 @@ module.exports = {
             'features/dynamicResponseDescription',
             'features/host',
             'features/afterScript',
+            'features/customScript',
             'features/oauth2',
             'features/postman',
             'features/globalParameter',

--- a/knife4j-vue/src/core/Knife4jAsync.js
+++ b/knife4j-vue/src/core/Knife4jAsync.js
@@ -66,6 +66,7 @@ import DebugAxios from 'axios';
 import { ref } from 'vue';
 
 import IncludeAssemble from './IncludeAssemble';
+import { loadCustomScripts } from './Knife4jExtension';
 
 marked.setOptions({
   gfm: true,
@@ -190,6 +191,7 @@ function SwaggerBootstrapUi(options) {
     enableCacheOpenApiTable: false, // 是否开启缓存已打开的api文档
     enableHost: false,// 是否启用Host
     enableHostText: '',// 启用Host后文本
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
     language: options.i18n || 'zh-CN' // 默认语言版本
   };
   // SwaggerBootstrapUi增强注解地址
@@ -928,6 +930,7 @@ SwaggerBootstrapUi.prototype.resolvedOASVersion = function (openApi) {
  * 全局配置set操作
  */
 SwaggerBootstrapUi.prototype.dispatchSettings = function () {
+  loadCustomScripts(this.settings.customJavaScriptUrls);
   this.store.dispatch('globals/setAfterScript', this.settings.enableAfterScript);
   this.store.dispatch('globals/setReloadCacheParameter', this.settings.enableReloadCacheParameter);
   // add 2022.8.11 xiaoymin

--- a/knife4j-vue/src/core/Knife4jExtension.cjs
+++ b/knife4j-vue/src/core/Knife4jExtension.cjs
@@ -1,0 +1,120 @@
+function defaultEnvironment() {
+  var browserWindow = typeof window !== 'undefined' ? window : {};
+  return {
+    window: browserWindow,
+    document: browserWindow.document || (typeof document !== 'undefined' ? document : null),
+    console: browserWindow.console || (typeof console !== 'undefined' ? console : null)
+  };
+}
+
+function normalizeScriptUrls(scriptUrls) {
+  if (!Array.isArray(scriptUrls)) {
+    return [];
+  }
+  return scriptUrls
+    .filter(function (scriptUrl) {
+      return typeof scriptUrl === 'string' && scriptUrl.trim() !== '';
+    })
+    .map(function (scriptUrl) {
+      return scriptUrl.trim();
+    });
+}
+
+function createKnife4jExtension(environment) {
+  var env = Object.assign(defaultEnvironment(), environment || {});
+  var loadedScriptUrls = {};
+  var requestInterceptors = [];
+
+  function warn(message, error) {
+    if (env.console && typeof env.console.warn === 'function') {
+      env.console.warn(message, error);
+    }
+  }
+
+  function registerRequestInterceptor(interceptor) {
+    if (typeof interceptor !== 'function') {
+      warn('Knife4j request interceptor must be a function.');
+      return;
+    }
+    requestInterceptors.push(interceptor);
+  }
+
+  function applyRequestInterceptors(config, context) {
+    var nextConfig = config || {};
+    var nextContext = context || {};
+    nextConfig.headers = nextConfig.headers || {};
+    for (var i = 0; i < requestInterceptors.length; i++) {
+      try {
+        var returnedConfig = requestInterceptors[i](nextConfig, nextContext);
+        if (returnedConfig && typeof returnedConfig.then === 'function') {
+          warn('Knife4j request interceptor must return config synchronously.');
+        } else if (returnedConfig) {
+          nextConfig = returnedConfig;
+          nextConfig.headers = nextConfig.headers || {};
+        }
+      } catch (error) {
+        warn('Knife4j request interceptor failed.', error);
+      }
+    }
+    return nextConfig;
+  }
+
+  function loadScript(scriptUrl) {
+    if (!env.document || !env.document.createElement) {
+      return Promise.resolve();
+    }
+    if (loadedScriptUrls[scriptUrl]) {
+      return Promise.resolve();
+    }
+    loadedScriptUrls[scriptUrl] = true;
+    return new Promise(function (resolve) {
+      var script = env.document.createElement('script');
+      script.src = scriptUrl;
+      script.async = false;
+      script.onload = function () {
+        resolve();
+      };
+      script.onerror = function (error) {
+        warn('Knife4j custom script load failed: ' + scriptUrl, error);
+        resolve();
+      };
+      (env.document.head || env.document.body).appendChild(script);
+    });
+  }
+
+  function loadCustomScripts(scriptUrls) {
+    var urls = normalizeScriptUrls(scriptUrls);
+    var chain = Promise.resolve();
+    urls.forEach(function (scriptUrl) {
+      chain = chain.then(function () {
+        return loadScript(scriptUrl);
+      });
+    });
+    return chain;
+  }
+
+  var api = {
+    registerRequestInterceptor: registerRequestInterceptor,
+    applyRequestInterceptors: applyRequestInterceptors,
+    loadCustomScripts: loadCustomScripts,
+    _requestInterceptors: requestInterceptors
+  };
+
+  if (env.window) {
+    var existingApi = env.window.Knife4j || {};
+    requestInterceptors = existingApi._requestInterceptors || requestInterceptors;
+    api._requestInterceptors = requestInterceptors;
+    api.registerRequestInterceptor = registerRequestInterceptor;
+    api.applyRequestInterceptors = applyRequestInterceptors;
+    api.loadCustomScripts = loadCustomScripts;
+    env.window.Knife4j = Object.assign(existingApi, api);
+    return env.window.Knife4j;
+  }
+
+  return api;
+}
+
+module.exports = {
+  createKnife4jExtension: createKnife4jExtension,
+  normalizeScriptUrls: normalizeScriptUrls
+};

--- a/knife4j-vue/src/core/Knife4jExtension.js
+++ b/knife4j-vue/src/core/Knife4jExtension.js
@@ -1,0 +1,84 @@
+function warn(message, error) {
+  if (window.console && typeof window.console.warn === 'function') {
+    window.console.warn(message, error);
+  }
+}
+
+function normalizeScriptUrls(scriptUrls) {
+  if (!Array.isArray(scriptUrls)) {
+    return [];
+  }
+  return scriptUrls
+    .filter(scriptUrl => typeof scriptUrl === 'string' && scriptUrl.trim() !== '')
+    .map(scriptUrl => scriptUrl.trim());
+}
+
+const existingApi = window.Knife4j || {};
+const loadedScriptUrls = {};
+const requestInterceptors = existingApi._requestInterceptors || [];
+
+function registerRequestInterceptor(interceptor) {
+  if (typeof interceptor !== 'function') {
+    warn('Knife4j request interceptor must be a function.');
+    return;
+  }
+  requestInterceptors.push(interceptor);
+}
+
+function applyRequestInterceptors(config, context) {
+  let nextConfig = config || {};
+  const nextContext = context || {};
+  nextConfig.headers = nextConfig.headers || {};
+  requestInterceptors.forEach(interceptor => {
+    try {
+      const returnedConfig = interceptor(nextConfig, nextContext);
+      if (returnedConfig && typeof returnedConfig.then === 'function') {
+        warn('Knife4j request interceptor must return config synchronously.');
+      } else if (returnedConfig) {
+        nextConfig = returnedConfig;
+        nextConfig.headers = nextConfig.headers || {};
+      }
+    } catch (error) {
+      warn('Knife4j request interceptor failed.', error);
+    }
+  });
+  return nextConfig;
+}
+
+function loadScript(scriptUrl) {
+  if (loadedScriptUrls[scriptUrl]) {
+    return Promise.resolve();
+  }
+  loadedScriptUrls[scriptUrl] = true;
+  return new Promise(resolve => {
+    const script = document.createElement('script');
+    script.src = scriptUrl;
+    script.async = false;
+    script.onload = () => resolve();
+    script.onerror = error => {
+      warn('Knife4j custom script load failed: ' + scriptUrl, error);
+      resolve();
+    };
+    (document.head || document.body).appendChild(script);
+  });
+}
+
+function loadCustomScripts(scriptUrls) {
+  let chain = Promise.resolve();
+  normalizeScriptUrls(scriptUrls).forEach(scriptUrl => {
+    chain = chain.then(() => loadScript(scriptUrl));
+  });
+  return chain;
+}
+
+const knife4jExtension = Object.assign(existingApi, {
+  registerRequestInterceptor,
+  applyRequestInterceptors,
+  loadCustomScripts,
+  _requestInterceptors: requestInterceptors
+});
+
+window.Knife4j = knife4jExtension;
+
+export default knife4jExtension;
+export { registerRequestInterceptor, applyRequestInterceptors, loadCustomScripts };

--- a/knife4j-vue/src/store/constants.js
+++ b/knife4j-vue/src/store/constants.js
@@ -69,6 +69,7 @@ const constants = {
     showTagStatus: false, // 分组tag显示description属性,针对@Api注解没有tags属性值的情况
     enableSwaggerBootstrapUi: false, // 是否开启swaggerBootstrapUi增强
     treeExplain: true,
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
 
     language: 'zh-CN' // 默认语言版本
   },
@@ -95,6 +96,7 @@ const constants = {
     showTagStatus: false, // 分组tag显示description属性,针对@Api注解没有tags属性值的情况
     enableSwaggerBootstrapUi: false, // 是否开启swaggerBootstrapUi增强
     treeExplain: true,
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
     enableDynamicParameter: false, // 开启动态参数
     enableFilterMultipartApis: false, // 针对RequestMapping的接口请求类型,在不指定参数类型的情况下,如果不过滤,默认会显示7个类型的接口地址参数,如果开启此配置,默认展示一个Post类型的接口地址
     enableFilterMultipartApiMethodType: 'POST', // 默认保存类型
@@ -126,6 +128,7 @@ const constants = {
     showTagStatus: false, // 分组tag显示description属性,针对@Api注解没有tags属性值的情况
     enableSwaggerBootstrapUi: true, // 是否开启swaggerBootstrapUi增强
     treeExplain: true,
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
     enableDynamicParameter: false, // 开启动态参数
     enableFilterMultipartApis: false, // 针对RequestMapping的接口请求类型,在不指定参数类型的情况下,如果不过滤,默认会显示7个类型的接口地址参数,如果开启此配置,默认展示一个Post类型的接口地址
     enableFilterMultipartApiMethodType: 'POST', // 默认保存类型

--- a/knife4j-vue/src/views/api/Debug.vue
+++ b/knife4j-vue/src/views/api/Debug.vue
@@ -275,6 +275,7 @@ import DebugResponse from "./DebugResponse"; */
 import DebugAxios from "axios";
 import cloneDeep from 'lodash/cloneDeep'
 import vkbeautify from "@/components/utils/vkbeautify";
+import { applyRequestInterceptors } from "@/core/Knife4jExtension";
 
 export default {
   name: "Debug",
@@ -388,6 +389,7 @@ export default {
       responseHeaders: [],
       responseRawText: "",
       responseCurlText: "",
+      debugRequestHeadersForCurl: null,
       responseStatus: null,
       responseContent: null,
       responseFieldDescriptionChecked: true,
@@ -427,6 +429,9 @@ export default {
     },
     enableReloadCacheParameter() {
       return this.$store.state.globals.enableReloadCacheParameter;
+    },
+    settings() {
+      return this.$store.state.globals.settings || {};
     }
   },
   watch: {
@@ -2465,6 +2470,25 @@ export default {
       // console.log("校验结果："+flag);
       return flag;
     },
+    buildRequestInterceptorContext(requestType, headers) {
+      return {
+        api: this.api,
+        swaggerInstance: this.swaggerInstance,
+        requestType: requestType,
+        settings: this.settings,
+        headers: headers
+      };
+    },
+    applyDebugRequestInterceptors(requestConfig, requestType) {
+      var nextConfig = applyRequestInterceptors(
+        requestConfig,
+        this.buildRequestInterceptorContext(requestType, requestConfig.headers)
+      );
+      nextConfig.headers = nextConfig.headers || {};
+      this.debugRequestHeadersForCurl = nextConfig.headers;
+      nextConfig.withCredentials = this.debugSendHasCookie(nextConfig.headers);
+      return nextConfig;
+    },
     applyRequestParams(formParams, methodType) {
       var requestData = null;
       var requestParams = null;
@@ -2576,6 +2600,7 @@ export default {
           // https://gitee.com/xiaoym/knife4j/issues/I374SP
           requestConfig = { ...requestConfig, responseType: "blob" };
         }
+        requestConfig = this.applyDebugRequestInterceptors(requestConfig, "urlForm");
         //console.log(requestConfig);
         //requestConfig.data = null;
         const debugInstance = DebugAxios.create();
@@ -2682,6 +2707,7 @@ export default {
           // 流请求
           requestConfig = { ...requestConfig, responseType: "blob" };
         }
+        requestConfig = this.applyDebugRequestInterceptors(requestConfig, "form");
         let debugInstance = DebugAxios.create();
         // console(headers);
         // console(requestConfig);
@@ -2778,6 +2804,7 @@ export default {
           // https://gitee.com/xiaoym/knife4j/issues/I374SP
           requestConfig = { ...requestConfig, responseType: "blob" };
         }
+        requestConfig = this.applyDebugRequestInterceptors(requestConfig, "raw");
         // console(headers);
         // console(this.rawText);
         var startTime = new Date();
@@ -3009,7 +3036,7 @@ export default {
       curlified.push("curl");
       curlified.push("-X", this.debugMethodType.toUpperCase());
       // 设置请求头
-      var headers = this.debugHeaders();
+      var headers = this.debugRequestHeadersForCurl || this.debugHeaders();
       var ignoreHeaders = [];
       ignoreHeaders.push("knife4j-gateway-request");
       ignoreHeaders.push("knife4j-gateway-code");

--- a/knife4j-vue3/src/core/Knife4jAsync.js
+++ b/knife4j-vue3/src/core/Knife4jAsync.js
@@ -49,6 +49,7 @@ import isUndefined from 'lodash/isUndefined';
 // import xml2js from 'xml2js';
 import DebugAxios from 'axios';
 import { useGlobalsStore } from '@/store/modules/global.js'
+import { loadCustomScripts } from './Knife4jExtension';
 
 marked.setOptions({
   gfm: true,
@@ -167,6 +168,7 @@ function SwaggerBootstrapUi(options) {
     enableCacheOpenApiTable: false, // 是否开启缓存已打开的api文档
     enableHost: false,// 是否启用Host
     enableHostText: '',// 启用Host后文本
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
     language: options.i18n || 'zh-CN' // 默认语言版本
   };
   // SwaggerBootstrapUi增强注解地址
@@ -902,6 +904,7 @@ SwaggerBootstrapUi.prototype.resolvedOASVersion = function (openApi) {
  * 全局配置set操作
  */
 SwaggerBootstrapUi.prototype.dispatchSettings = function () {
+  loadCustomScripts(this.settings.customJavaScriptUrls)
   const globalsStore = useGlobalsStore()
   globalsStore.setAfterScript(this.settings.enableAfterScript)
   globalsStore.setReloadCacheParameter(this.settings.enableReloadCacheParameter)

--- a/knife4j-vue3/src/core/Knife4jExtension.cjs
+++ b/knife4j-vue3/src/core/Knife4jExtension.cjs
@@ -1,0 +1,120 @@
+function defaultEnvironment() {
+  var browserWindow = typeof window !== 'undefined' ? window : {};
+  return {
+    window: browserWindow,
+    document: browserWindow.document || (typeof document !== 'undefined' ? document : null),
+    console: browserWindow.console || (typeof console !== 'undefined' ? console : null)
+  };
+}
+
+function normalizeScriptUrls(scriptUrls) {
+  if (!Array.isArray(scriptUrls)) {
+    return [];
+  }
+  return scriptUrls
+    .filter(function (scriptUrl) {
+      return typeof scriptUrl === 'string' && scriptUrl.trim() !== '';
+    })
+    .map(function (scriptUrl) {
+      return scriptUrl.trim();
+    });
+}
+
+function createKnife4jExtension(environment) {
+  var env = Object.assign(defaultEnvironment(), environment || {});
+  var loadedScriptUrls = {};
+  var requestInterceptors = [];
+
+  function warn(message, error) {
+    if (env.console && typeof env.console.warn === 'function') {
+      env.console.warn(message, error);
+    }
+  }
+
+  function registerRequestInterceptor(interceptor) {
+    if (typeof interceptor !== 'function') {
+      warn('Knife4j request interceptor must be a function.');
+      return;
+    }
+    requestInterceptors.push(interceptor);
+  }
+
+  function applyRequestInterceptors(config, context) {
+    var nextConfig = config || {};
+    var nextContext = context || {};
+    nextConfig.headers = nextConfig.headers || {};
+    for (var i = 0; i < requestInterceptors.length; i++) {
+      try {
+        var returnedConfig = requestInterceptors[i](nextConfig, nextContext);
+        if (returnedConfig && typeof returnedConfig.then === 'function') {
+          warn('Knife4j request interceptor must return config synchronously.');
+        } else if (returnedConfig) {
+          nextConfig = returnedConfig;
+          nextConfig.headers = nextConfig.headers || {};
+        }
+      } catch (error) {
+        warn('Knife4j request interceptor failed.', error);
+      }
+    }
+    return nextConfig;
+  }
+
+  function loadScript(scriptUrl) {
+    if (!env.document || !env.document.createElement) {
+      return Promise.resolve();
+    }
+    if (loadedScriptUrls[scriptUrl]) {
+      return Promise.resolve();
+    }
+    loadedScriptUrls[scriptUrl] = true;
+    return new Promise(function (resolve) {
+      var script = env.document.createElement('script');
+      script.src = scriptUrl;
+      script.async = false;
+      script.onload = function () {
+        resolve();
+      };
+      script.onerror = function (error) {
+        warn('Knife4j custom script load failed: ' + scriptUrl, error);
+        resolve();
+      };
+      (env.document.head || env.document.body).appendChild(script);
+    });
+  }
+
+  function loadCustomScripts(scriptUrls) {
+    var urls = normalizeScriptUrls(scriptUrls);
+    var chain = Promise.resolve();
+    urls.forEach(function (scriptUrl) {
+      chain = chain.then(function () {
+        return loadScript(scriptUrl);
+      });
+    });
+    return chain;
+  }
+
+  var api = {
+    registerRequestInterceptor: registerRequestInterceptor,
+    applyRequestInterceptors: applyRequestInterceptors,
+    loadCustomScripts: loadCustomScripts,
+    _requestInterceptors: requestInterceptors
+  };
+
+  if (env.window) {
+    var existingApi = env.window.Knife4j || {};
+    requestInterceptors = existingApi._requestInterceptors || requestInterceptors;
+    api._requestInterceptors = requestInterceptors;
+    api.registerRequestInterceptor = registerRequestInterceptor;
+    api.applyRequestInterceptors = applyRequestInterceptors;
+    api.loadCustomScripts = loadCustomScripts;
+    env.window.Knife4j = Object.assign(existingApi, api);
+    return env.window.Knife4j;
+  }
+
+  return api;
+}
+
+module.exports = {
+  createKnife4jExtension: createKnife4jExtension,
+  normalizeScriptUrls: normalizeScriptUrls
+};

--- a/knife4j-vue3/src/core/Knife4jExtension.js
+++ b/knife4j-vue3/src/core/Knife4jExtension.js
@@ -1,0 +1,84 @@
+function warn(message, error) {
+  if (window.console && typeof window.console.warn === 'function') {
+    window.console.warn(message, error);
+  }
+}
+
+function normalizeScriptUrls(scriptUrls) {
+  if (!Array.isArray(scriptUrls)) {
+    return [];
+  }
+  return scriptUrls
+    .filter(scriptUrl => typeof scriptUrl === 'string' && scriptUrl.trim() !== '')
+    .map(scriptUrl => scriptUrl.trim());
+}
+
+const existingApi = window.Knife4j || {};
+const loadedScriptUrls = {};
+const requestInterceptors = existingApi._requestInterceptors || [];
+
+function registerRequestInterceptor(interceptor) {
+  if (typeof interceptor !== 'function') {
+    warn('Knife4j request interceptor must be a function.');
+    return;
+  }
+  requestInterceptors.push(interceptor);
+}
+
+function applyRequestInterceptors(config, context) {
+  let nextConfig = config || {};
+  const nextContext = context || {};
+  nextConfig.headers = nextConfig.headers || {};
+  requestInterceptors.forEach(interceptor => {
+    try {
+      const returnedConfig = interceptor(nextConfig, nextContext);
+      if (returnedConfig && typeof returnedConfig.then === 'function') {
+        warn('Knife4j request interceptor must return config synchronously.');
+      } else if (returnedConfig) {
+        nextConfig = returnedConfig;
+        nextConfig.headers = nextConfig.headers || {};
+      }
+    } catch (error) {
+      warn('Knife4j request interceptor failed.', error);
+    }
+  });
+  return nextConfig;
+}
+
+function loadScript(scriptUrl) {
+  if (loadedScriptUrls[scriptUrl]) {
+    return Promise.resolve();
+  }
+  loadedScriptUrls[scriptUrl] = true;
+  return new Promise(resolve => {
+    const script = document.createElement('script');
+    script.src = scriptUrl;
+    script.async = false;
+    script.onload = () => resolve();
+    script.onerror = error => {
+      warn('Knife4j custom script load failed: ' + scriptUrl, error);
+      resolve();
+    };
+    (document.head || document.body).appendChild(script);
+  });
+}
+
+function loadCustomScripts(scriptUrls) {
+  let chain = Promise.resolve();
+  normalizeScriptUrls(scriptUrls).forEach(scriptUrl => {
+    chain = chain.then(() => loadScript(scriptUrl));
+  });
+  return chain;
+}
+
+const knife4jExtension = Object.assign(existingApi, {
+  registerRequestInterceptor,
+  applyRequestInterceptors,
+  loadCustomScripts,
+  _requestInterceptors: requestInterceptors
+});
+
+window.Knife4j = knife4jExtension;
+
+export default knife4jExtension;
+export { registerRequestInterceptor, applyRequestInterceptors, loadCustomScripts };

--- a/knife4j-vue3/src/store/constants.js
+++ b/knife4j-vue3/src/store/constants.js
@@ -69,6 +69,7 @@ const constants = {
     showTagStatus: false, // 分组tag显示description属性,针对@Api注解没有tags属性值的情况
     enableSwaggerBootstrapUi: false, // 是否开启swaggerBootstrapUi增强
     treeExplain: true,
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
 
     language: 'zh-CN' // 默认语言版本
   },
@@ -95,6 +96,7 @@ const constants = {
     showTagStatus: false, // 分组tag显示description属性,针对@Api注解没有tags属性值的情况
     enableSwaggerBootstrapUi: false, // 是否开启swaggerBootstrapUi增强
     treeExplain: true,
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
     enableDynamicParameter: false, // 开启动态参数
     enableFilterMultipartApis: false, // 针对RequestMapping的接口请求类型,在不指定参数类型的情况下,如果不过滤,默认会显示7个类型的接口地址参数,如果开启此配置,默认展示一个Post类型的接口地址
     enableFilterMultipartApiMethodType: 'POST', // 默认保存类型
@@ -126,6 +128,7 @@ const constants = {
     showTagStatus: false, // 分组tag显示description属性,针对@Api注解没有tags属性值的情况
     enableSwaggerBootstrapUi: true, // 是否开启swaggerBootstrapUi增强
     treeExplain: true,
+    customJavaScriptUrls: [], // 自定义JavaScript脚本地址
     enableDynamicParameter: false, // 开启动态参数
     enableFilterMultipartApis: false, // 针对RequestMapping的接口请求类型,在不指定参数类型的情况下,如果不过滤,默认会显示7个类型的接口地址参数,如果开启此配置,默认展示一个Post类型的接口地址
     enableFilterMultipartApiMethodType: 'POST', // 默认保存类型

--- a/knife4j-vue3/src/views/api/Debug.vue
+++ b/knife4j-vue3/src/views/api/Debug.vue
@@ -284,6 +284,7 @@ import { useI18n } from 'vue-i18n'
 import { message } from 'ant-design-vue'
 import localStore from '@/store/local.js'
 import { UnlockOutlined, DownOutlined } from '@ant-design/icons-vue'
+import { applyRequestInterceptors } from "@/core/Knife4jExtension";
 
 export default {
   name: "Debug",
@@ -315,6 +316,9 @@ export default {
     const enableReloadCacheParameter = computed(() => {
       return globalsStore.enableReloadCacheParameter;
     })
+    const settings = computed(() => {
+      return globalsStore.settings || {};
+    })
 
     const knife4jModels = useknife4jModels()
     const { messages } = useI18n()
@@ -322,6 +326,7 @@ export default {
       language,
       enableAfterScript,
       enableReloadCacheParameter,
+      settings,
       knife4jModels,
       messages
     }
@@ -421,6 +426,7 @@ export default {
       responseHeaders: [],
       responseRawText: "",
       responseCurlText: "",
+      debugRequestHeadersForCurl: null,
       responseStatus: null,
       responseContent: null,
       responseFieldDescriptionChecked: true,
@@ -2474,6 +2480,25 @@ export default {
       // console.log("校验结果："+flag);
       return flag;
     },
+    buildRequestInterceptorContext(requestType, headers) {
+      return {
+        api: this.api,
+        swaggerInstance: this.swaggerInstance,
+        requestType: requestType,
+        settings: this.settings,
+        headers: headers
+      };
+    },
+    applyDebugRequestInterceptors(requestConfig, requestType) {
+      var nextConfig = applyRequestInterceptors(
+        requestConfig,
+        this.buildRequestInterceptorContext(requestType, requestConfig.headers)
+      );
+      nextConfig.headers = nextConfig.headers || {};
+      this.debugRequestHeadersForCurl = nextConfig.headers;
+      nextConfig.withCredentials = this.debugSendHasCookie(nextConfig.headers);
+      return nextConfig;
+    },
     applyRequestParams(formParams, methodType) {
       var requestData = null;
       var requestParams = null;
@@ -2585,6 +2610,7 @@ export default {
           // https://gitee.com/xiaoym/knife4j/issues/I374SP
           requestConfig = { ...requestConfig, responseType: "blob" };
         }
+        requestConfig = this.applyDebugRequestInterceptors(requestConfig, "urlForm");
         // console.log(requestConfig);
         const debugInstance = DebugAxios.create();
         // get请求编码问题
@@ -2690,6 +2716,7 @@ export default {
           // 流请求
           requestConfig = { ...requestConfig, responseType: "blob" };
         }
+        requestConfig = this.applyDebugRequestInterceptors(requestConfig, "form");
         let debugInstance = DebugAxios.create();
         // console(headers);
         // console(requestConfig);
@@ -2777,6 +2804,7 @@ export default {
           // 流请求
           requestConfig = { ...requestConfig, responseType: "blob" };
         }
+        requestConfig = this.applyDebugRequestInterceptors(requestConfig, "raw");
         // console(headers);
         // console(this.rawText);
         var startTime = new Date();
@@ -2994,7 +3022,7 @@ export default {
       curlified.push("curl");
       curlified.push("-X", this.debugMethodType.toUpperCase());
       // 设置请求头
-      var headers = this.debugHeaders();
+      var headers = this.debugRequestHeadersForCurl || this.debugHeaders();
       var ignoreHeaders = [];
       ignoreHeaders.push("knfie4j-gateway-request");
       ignoreHeaders.push("knife4j-gateway-code");

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/extend/OpenApiExtendSetting.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/extend/OpenApiExtendSetting.java
@@ -17,13 +17,16 @@
 
 package com.github.xiaoymin.knife4j.core.extend;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author <a href="mailto:xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
  * 2020/10/24 6:56
  * @since  2.0.6
  */
 public class OpenApiExtendSetting {
-    
+
     /**
      * Ui语言版本
      */
@@ -36,17 +39,22 @@ public class OpenApiExtendSetting {
      * 重命名SwaggerModel名称,默认
      */
     private String swaggerModelName = "Swagger Models";
-    
+
     /**
      * 是否在每个Debug调试栏后显示刷新变量按钮,默认不显示
      */
     private boolean enableReloadCacheParameter = false;
-    
+
     /**
      * 调试Tab是否显示AfterScript功能,默认开启
      */
     private boolean enableAfterScript = true;
-    
+
+    /**
+     * 自定义JavaScript脚本地址
+     */
+    private List<String> customJavaScriptUrls = new ArrayList<>();
+
     /**
      * 是否显示界面中"文档管理"功能
      */
@@ -55,42 +63,42 @@ public class OpenApiExtendSetting {
      * 是否开启界面中对某接口的版本控制,如果开启，后端变化后Ui界面会存在小蓝点
      */
     private boolean enableVersion = false;
-    
+
     /**
      * 是否开启请求参数缓存
      */
     private boolean enableRequestCache = true;
-    
+
     /**
      * 针对RequestMapping的接口请求类型,在不指定参数类型的情况下,如果不过滤,默认会显示7个类型的接口地址参数,如果开启此配置,默认展示一个Post类型的接口地址
      */
     private boolean enableFilterMultipartApis = false;
-    
+
     /**
      * 过滤类型
      */
     private String enableFilterMultipartApiMethodType = "POST";
-    
+
     /**
      * 是否启用Host
      */
     private boolean enableHost = false;
-    
+
     /**
      * 启用Host后文本
      */
     private String enableHostText = "";
-    
+
     /**
      * 是否开启动态请求参数
      */
     private boolean enableDynamicParameter = false;
-    
+
     /**
      * 是否开启debug调试
      */
     private boolean enableDebug = true;
-    
+
     /**
      * 是否默认显示底部Footer
      */
@@ -99,224 +107,232 @@ public class OpenApiExtendSetting {
      * 是否自定义Footer
      */
     private boolean enableFooterCustom = false;
-    
+
     /**
      * 自定义Footer内容(支持Markdown语法)
      */
     private String footerCustomContent;
-    
+
     /**
      * 是否显示搜索框
      */
     private boolean enableSearch = true;
-    
+
     /**
      * 是否显示OpenAPI原始结构的Tab框，默认显示
      */
     private boolean enableOpenApi = true;
-    
+
     /**
      * 是否开启主页自定义配置，默认false
      */
     private boolean enableHomeCustom = false;
-    
+
     /**
      * 自定义主页的Markdown文档路径
      */
     private String homeCustomLocation;
-    
+
     /**
      * 是否显示分组下拉框，默认true(即显示)，一般情况下，如果是单个分组的情况下，可以设置该属性为false，即不显示分组，那么也就不用选择了
      */
     private boolean enableGroup = true;
-    
+
     /**
      * 是否显示响应状态码栏
      * https://gitee.com/xiaoym/knife4j/issues/I3TE0V
      * @since v4.0.0
      */
     private boolean enableResponseCode = true;
-    
+
     public boolean isEnableResponseCode() {
         return enableResponseCode;
     }
-    
+
     public void setEnableResponseCode(boolean enableResponseCode) {
         this.enableResponseCode = enableResponseCode;
     }
-    
+
     public boolean isEnableGroup() {
         return enableGroup;
     }
-    
+
     public void setEnableGroup(boolean enableGroup) {
         this.enableGroup = enableGroup;
     }
-    
+
     public String getLanguage() {
         return language;
     }
-    
+
     public void setLanguage(String language) {
         this.language = language;
     }
-    
+
     public boolean isEnableRequestCache() {
         return enableRequestCache;
     }
-    
+
     public void setEnableRequestCache(boolean enableRequestCache) {
         this.enableRequestCache = enableRequestCache;
     }
-    
+
     public boolean isEnableFilterMultipartApis() {
         return enableFilterMultipartApis;
     }
-    
+
     public void setEnableFilterMultipartApis(boolean enableFilterMultipartApis) {
         this.enableFilterMultipartApis = enableFilterMultipartApis;
     }
-    
+
     public String getEnableFilterMultipartApiMethodType() {
         return enableFilterMultipartApiMethodType;
     }
-    
+
     public void setEnableFilterMultipartApiMethodType(String enableFilterMultipartApiMethodType) {
         this.enableFilterMultipartApiMethodType = enableFilterMultipartApiMethodType;
     }
-    
+
     public boolean isEnableHost() {
         return enableHost;
     }
-    
+
     public void setEnableHost(boolean enableHost) {
         this.enableHost = enableHost;
     }
-    
+
     public String getEnableHostText() {
         return enableHostText;
     }
-    
+
     public void setEnableHostText(String enableHostText) {
         this.enableHostText = enableHostText;
     }
-    
+
     public boolean isEnableSwaggerModels() {
         return enableSwaggerModels;
     }
-    
+
     public void setEnableSwaggerModels(boolean enableSwaggerModels) {
         this.enableSwaggerModels = enableSwaggerModels;
     }
-    
+
     public boolean isEnableDocumentManage() {
         return enableDocumentManage;
     }
-    
+
     public void setEnableDocumentManage(boolean enableDocumentManage) {
         this.enableDocumentManage = enableDocumentManage;
     }
-    
+
     public boolean isEnableVersion() {
         return enableVersion;
     }
-    
+
     public void setEnableVersion(boolean enableVersion) {
         this.enableVersion = enableVersion;
     }
-    
+
     public String getSwaggerModelName() {
         return swaggerModelName;
     }
-    
+
     public void setSwaggerModelName(String swaggerModelName) {
         this.swaggerModelName = swaggerModelName;
     }
-    
+
     public boolean isEnableAfterScript() {
         return enableAfterScript;
     }
-    
+
     public void setEnableAfterScript(boolean enableAfterScript) {
         this.enableAfterScript = enableAfterScript;
     }
-    
+
+    public List<String> getCustomJavaScriptUrls() {
+        return customJavaScriptUrls;
+    }
+
+    public void setCustomJavaScriptUrls(List<String> customJavaScriptUrls) {
+        this.customJavaScriptUrls = customJavaScriptUrls;
+    }
+
     public boolean isEnableReloadCacheParameter() {
         return enableReloadCacheParameter;
     }
-    
+
     public void setEnableReloadCacheParameter(boolean enableReloadCacheParameter) {
         this.enableReloadCacheParameter = enableReloadCacheParameter;
     }
-    
+
     public boolean isEnableDynamicParameter() {
         return enableDynamicParameter;
     }
-    
+
     public void setEnableDynamicParameter(boolean enableDynamicParameter) {
         this.enableDynamicParameter = enableDynamicParameter;
     }
-    
+
     public boolean isEnableDebug() {
         return enableDebug;
     }
-    
+
     public void setEnableDebug(boolean enableDebug) {
         this.enableDebug = enableDebug;
     }
-    
+
     public boolean isEnableFooter() {
         return enableFooter;
     }
-    
+
     public void setEnableFooter(boolean enableFooter) {
         this.enableFooter = enableFooter;
     }
-    
+
     public boolean isEnableFooterCustom() {
         return enableFooterCustom;
     }
-    
+
     public void setEnableFooterCustom(boolean enableFooterCustom) {
         this.enableFooterCustom = enableFooterCustom;
     }
-    
+
     public String getFooterCustomContent() {
         return footerCustomContent;
     }
-    
+
     public void setFooterCustomContent(String footerCustomContent) {
         this.footerCustomContent = footerCustomContent;
     }
-    
+
     public boolean isEnableSearch() {
         return enableSearch;
     }
-    
+
     public void setEnableSearch(boolean enableSearch) {
         this.enableSearch = enableSearch;
     }
-    
+
     public boolean isEnableOpenApi() {
         return enableOpenApi;
     }
-    
+
     public void setEnableOpenApi(boolean enableOpenApi) {
         this.enableOpenApi = enableOpenApi;
     }
-    
+
     public boolean isEnableHomeCustom() {
         return enableHomeCustom;
     }
-    
+
     public void setEnableHomeCustom(boolean enableHomeCustom) {
         this.enableHomeCustom = enableHomeCustom;
     }
-    
+
     public String getHomeCustomLocation() {
         return homeCustomLocation;
     }
-    
+
     public void setHomeCustomLocation(String homeCustomLocation) {
         this.homeCustomLocation = homeCustomLocation;
     }

--- a/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
@@ -106,6 +106,13 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 

--- a/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -18,6 +18,8 @@
 package com.github.xiaoymin.knife4j.spring.configuration;
 
 import com.github.xiaoymin.knife4j.core.enums.OpenAPILanguageEnums;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -29,7 +31,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "knife4j.setting")
 public class Knife4jSetting {
-    
+
     /**
      * Custom response HTTP status code after production environment screening(Knife4j.production=true)
      */
@@ -46,17 +48,22 @@ public class Knife4jSetting {
      * Rename Swagger model name,default is `Swagger Models`
      */
     private String swaggerModelName = "Swagger Models";
-    
+
     /**
      * Whether to display the refresh variable button after each debug debugging bar, which is not displayed by default
      */
     private boolean enableReloadCacheParameter = false;
-    
+
     /**
      * Whether the debug tab displays the afterScript function is enabled by default
      */
     private boolean enableAfterScript = true;
-    
+
+    /**
+     * Custom JavaScript urls loaded by doc.html.
+     */
+    private List<String> customJavaScriptUrls = new ArrayList<>();
+
     /**
      * Whether to display the "document management" function in the Ui Part.
      */
@@ -65,42 +72,42 @@ public class Knife4jSetting {
      * Whether to enable the version control of an interface in the interface. If it is enabled, the UI interface will have small blue dots after the backend changes
      */
     private boolean enableVersion = false;
-    
+
     /**
      * Whether to enable request parameter cache
      */
     private boolean enableRequestCache = true;
-    
+
     /**
      * For the interface request type of RequestMapping, if the parameter type is not specified, seven types of interface address parameters will be displayed by default if filtering is not performed. If this configuration is enabled, an interface address of post type will be displayed by default
      */
     private boolean enableFilterMultipartApis = false;
-    
+
     /**
      * Filter Method type
      */
     private String enableFilterMultipartApiMethodType = "POST";
-    
+
     /**
      * Enable host
      */
     private boolean enableHost = false;
-    
+
     /**
      * HostAddress after enabling host
      */
     private String enableHostText = "";
-    
+
     /**
      * Whether to enable dynamic request parameters
      */
     private boolean enableDynamicParameter = false;
-    
+
     /**
      * Enable debug mode，default is true.
      */
     private boolean enableDebug = true;
-    
+
     /**
      * Display bottom footer by default
      */
@@ -109,42 +116,42 @@ public class Knife4jSetting {
      * Customize footer
      */
     private boolean enableFooterCustom = false;
-    
+
     /**
      * Custom footer content (support Markdown syntax)
      */
     private String footerCustomContent;
-    
+
     /**
      * Show search box
      */
     private boolean enableSearch = true;
-    
+
     /**
      * Whether to display the tab box of the original structure of OpenAPI, which is displayed by default
      */
     private boolean enableOpenApi = true;
-    
+
     /**
      * Whether to enable home page custom configuration, false by default
      */
     private boolean enableHomeCustom = false;
-    
+
     /**
      * Customize Markdown document path of home page
      */
     private String homeCustomLocation;
-    
+
     /**
      * Whether to display the group drop-down box, the default is true (that is, display). In general, if it is a single group, you can set this property to false, that is, the group will not be displayed, so you don't need to select it.
      */
     private boolean enableGroup = true;
-    
+
     /**
      * Whether to display the response status code bar
      * https://gitee.com/xiaoym/knife4j/issues/I3TE0V
      * @since v4.0.0
      */
     private boolean enableResponseCode = true;
-    
+
 }

--- a/knife4j/knife4j-openapi2-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSettingBindingTest.java
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSettingBindingTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Knife4jSettingBindingTest {
+
+    @Test
+    public void bindCustomJavaScriptUrlsFromConfigurationProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("knife4j.setting.custom-java-script-urls[0]", "/knife4j/custom/request-id.js");
+        properties.put("knife4j.setting.custom-java-script-urls[1]", "https://cdn.example.com/knife4j/debug.js");
+
+        try (AnnotationConfigApplicationContext context = loadContext(properties)) {
+            Knife4jSetting setting = context.getBean(Knife4jSetting.class);
+
+            Assert.assertEquals(Arrays.asList("/knife4j/custom/request-id.js", "https://cdn.example.com/knife4j/debug.js"),
+                    setting.getCustomJavaScriptUrls());
+        }
+    }
+
+    @Test
+    public void defaultCustomJavaScriptUrlsIsEmptyList() {
+        try (AnnotationConfigApplicationContext context = loadContext(Collections.emptyMap())) {
+            Knife4jSetting setting = context.getBean(Knife4jSetting.class);
+
+            Assert.assertNotNull(setting.getCustomJavaScriptUrls());
+            Assert.assertTrue(setting.getCustomJavaScriptUrls().isEmpty());
+        }
+    }
+
+    private AnnotationConfigApplicationContext loadContext(Map<String, Object> properties) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.setEnvironment(environment);
+        context.register(TestConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(Knife4jSetting.class)
+    static class TestConfiguration {
+    }
+}

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -49,6 +49,12 @@
             <scope>provided</scope>
             <version>${knife4j-servlet-jakarta.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -18,6 +18,8 @@
 package com.github.xiaoymin.knife4j.spring.configuration;
 
 import com.github.xiaoymin.knife4j.core.enums.OpenAPILanguageEnums;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -29,7 +31,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "knife4j.setting")
 public class Knife4jSetting {
-    
+
     /**
      * Custom response HTTP status code after production environment screening(Knife4j.production=true)
      */
@@ -46,17 +48,22 @@ public class Knife4jSetting {
      * Rename Swagger model name,default is `Swagger Models`
      */
     private String swaggerModelName = "Swagger Models";
-    
+
     /**
      * Whether to display the refresh variable button after each debug debugging bar, which is not displayed by default
      */
     private boolean enableReloadCacheParameter = false;
-    
+
     /**
      * Whether the debug tab displays the afterScript function is enabled by default
      */
     private boolean enableAfterScript = true;
-    
+
+    /**
+     * Custom JavaScript urls loaded by doc.html.
+     */
+    private List<String> customJavaScriptUrls = new ArrayList<>();
+
     /**
      * Whether to display the "document management" function in the Ui Part.
      */
@@ -65,42 +72,42 @@ public class Knife4jSetting {
      * Whether to enable the version control of an interface in the interface. If it is enabled, the UI interface will have small blue dots after the backend changes
      */
     private boolean enableVersion = false;
-    
+
     /**
      * Whether to enable request parameter cache
      */
     private boolean enableRequestCache = true;
-    
+
     /**
      * For the interface request type of RequestMapping, if the parameter type is not specified, seven types of interface address parameters will be displayed by default if filtering is not performed. If this configuration is enabled, an interface address of post type will be displayed by default
      */
     private boolean enableFilterMultipartApis = false;
-    
+
     /**
      * Filter Method type
      */
     private String enableFilterMultipartApiMethodType = "POST";
-    
+
     /**
      * Enable host
      */
     private boolean enableHost = false;
-    
+
     /**
      * HostAddress after enabling host
      */
     private String enableHostText = "";
-    
+
     /**
      * Whether to enable dynamic request parameters
      */
     private boolean enableDynamicParameter = false;
-    
+
     /**
      * Enable debug mode，default is true.
      */
     private boolean enableDebug = true;
-    
+
     /**
      * Display bottom footer by default
      */
@@ -109,47 +116,47 @@ public class Knife4jSetting {
      * Customize footer
      */
     private boolean enableFooterCustom = false;
-    
+
     /**
      * Custom footer content (support Markdown syntax)
      */
     private String footerCustomContent;
-    
+
     /**
      * Show search box
      */
     private boolean enableSearch = true;
-    
+
     /**
      * Whether to display the tab box of the original structure of OpenAPI, which is displayed by default
      */
     private boolean enableOpenApi = true;
-    
+
     /**
      * Whether to enable home page custom configuration, false by default
      */
     private boolean enableHomeCustom = false;
-    
+
     /**
      * Customize Markdown document path of home page
      */
     private String homeCustomLocation;
-    
+
     /**
      * Customize Markdown document path of home page
      */
     private String homeCustomPath;
-    
+
     /**
      * Whether to display the group drop-down box, the default is true (that is, display). In general, if it is a single group, you can set this property to false, that is, the group will not be displayed, so you don't need to select it.
      */
     private boolean enableGroup = true;
-    
+
     /**
      * Whether to display the response status code bar
      * https://gitee.com/xiaoym/knife4j/issues/I3TE0V
      * @since v4.0.0
      */
     private boolean enableResponseCode = true;
-    
+
 }

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSettingBindingTest.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSettingBindingTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Knife4jSettingBindingTest {
+
+    @Test
+    public void bindCustomJavaScriptUrlsFromConfigurationProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("knife4j.setting.custom-java-script-urls[0]", "/knife4j/custom/request-id.js");
+        properties.put("knife4j.setting.custom-java-script-urls[1]", "https://cdn.example.com/knife4j/debug.js");
+
+        try (AnnotationConfigApplicationContext context = loadContext(properties)) {
+            Knife4jSetting setting = context.getBean(Knife4jSetting.class);
+
+            Assert.assertEquals(Arrays.asList("/knife4j/custom/request-id.js", "https://cdn.example.com/knife4j/debug.js"),
+                    setting.getCustomJavaScriptUrls());
+        }
+    }
+
+    @Test
+    public void defaultCustomJavaScriptUrlsIsEmptyList() {
+        try (AnnotationConfigApplicationContext context = loadContext(Collections.emptyMap())) {
+            Knife4jSetting setting = context.getBean(Knife4jSetting.class);
+
+            Assert.assertNotNull(setting.getCustomJavaScriptUrls());
+            Assert.assertTrue(setting.getCustomJavaScriptUrls().isEmpty());
+        }
+    }
+
+    private AnnotationConfigApplicationContext loadContext(Map<String, Object> properties) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.setEnvironment(environment);
+        context.register(TestConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(Knife4jSetting.class)
+    static class TestConfiguration {
+    }
+}

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -18,6 +18,8 @@
 package com.github.xiaoymin.knife4j.spring.configuration;
 
 import com.github.xiaoymin.knife4j.core.enums.OpenAPILanguageEnums;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -29,7 +31,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "knife4j.setting")
 public class Knife4jSetting {
-    
+
     /**
      * Custom response HTTP status code after production environment screening(Knife4j.production=true)
      */
@@ -46,17 +48,22 @@ public class Knife4jSetting {
      * Rename Swagger model name,default is `Swagger Models`
      */
     private String swaggerModelName = "Swagger Models";
-    
+
     /**
      * Whether to display the refresh variable button after each debug debugging bar, which is not displayed by default
      */
     private boolean enableReloadCacheParameter = false;
-    
+
     /**
      * Whether the debug tab displays the afterScript function is enabled by default
      */
     private boolean enableAfterScript = true;
-    
+
+    /**
+     * Custom JavaScript urls loaded by doc.html.
+     */
+    private List<String> customJavaScriptUrls = new ArrayList<>();
+
     /**
      * Whether to display the "document management" function in the Ui Part.
      */
@@ -65,42 +72,42 @@ public class Knife4jSetting {
      * Whether to enable the version control of an interface in the interface. If it is enabled, the UI interface will have small blue dots after the backend changes
      */
     private boolean enableVersion = false;
-    
+
     /**
      * Whether to enable request parameter cache
      */
     private boolean enableRequestCache = true;
-    
+
     /**
      * For the interface request type of RequestMapping, if the parameter type is not specified, seven types of interface address parameters will be displayed by default if filtering is not performed. If this configuration is enabled, an interface address of post type will be displayed by default
      */
     private boolean enableFilterMultipartApis = false;
-    
+
     /**
      * Filter Method type
      */
     private String enableFilterMultipartApiMethodType = "POST";
-    
+
     /**
      * Enable host
      */
     private boolean enableHost = false;
-    
+
     /**
      * HostAddress after enabling host
      */
     private String enableHostText = "";
-    
+
     /**
      * Whether to enable dynamic request parameters
      */
     private boolean enableDynamicParameter = false;
-    
+
     /**
      * Enable debug mode，default is true.
      */
     private boolean enableDebug = true;
-    
+
     /**
      * Display bottom footer by default
      */
@@ -109,32 +116,32 @@ public class Knife4jSetting {
      * Customize footer
      */
     private boolean enableFooterCustom = false;
-    
+
     /**
      * Custom footer content (support Markdown syntax)
      */
     private String footerCustomContent;
-    
+
     /**
      * Show search box
      */
     private boolean enableSearch = true;
-    
+
     /**
      * Whether to display the tab box of the original structure of OpenAPI, which is displayed by default
      */
     private boolean enableOpenApi = true;
-    
+
     /**
      * Whether to enable home page custom configuration, false by default
      */
     private boolean enableHomeCustom = false;
-    
+
     /**
      * Customize Markdown document content of home page
      */
     private String homeCustomLocation;
-    
+
     /**
      * Customize Markdown document path of home page
      */
@@ -143,12 +150,12 @@ public class Knife4jSetting {
      * Whether to display the group drop-down box, the default is true (that is, display). In general, if it is a single group, you can set this property to false, that is, the group will not be displayed, so you don't need to select it.
      */
     private boolean enableGroup = true;
-    
+
     /**
      * Whether to display the response status code bar
      * https://gitee.com/xiaoym/knife4j/issues/I3TE0V
      * @since v4.0.0
      */
     private boolean enableResponseCode = true;
-    
+
 }

--- a/tests/custom-script-extension.test.cjs
+++ b/tests/custom-script-extension.test.cjs
@@ -1,0 +1,113 @@
+const assert = require('assert');
+const path = require('path');
+
+const extension = require('../knife4j-vue/src/core/Knife4jExtension.cjs');
+
+async function testRequestInterceptors() {
+  const warnMessages = [];
+  const api = extension.createKnife4jExtension({
+    console: {
+      warn: function (message) {
+        warnMessages.push(String(message));
+      }
+    }
+  });
+
+  api.registerRequestInterceptor(function (config, context) {
+    assert.strictEqual(context.requestType, 'raw');
+    config.headers['x-request-id'] = 'rid-1';
+    return config;
+  });
+  api.registerRequestInterceptor(function () {
+    throw new Error('broken interceptor');
+  });
+  api.registerRequestInterceptor(function (config) {
+    config.headers['x-extra'] = 'ok';
+  });
+
+  const requestConfig = api.applyRequestInterceptors({
+    url: '/pets',
+    headers: {}
+  }, {
+    requestType: 'raw'
+  });
+
+  assert.strictEqual(requestConfig.headers['x-request-id'], 'rid-1');
+  assert.strictEqual(requestConfig.headers['x-extra'], 'ok');
+  assert.strictEqual(warnMessages.length, 1);
+}
+
+async function testPromiseInterceptorIsIgnored() {
+  const warnMessages = [];
+  const api = extension.createKnife4jExtension({
+    console: {
+      warn: function (message) {
+        warnMessages.push(String(message));
+      }
+    }
+  });
+
+  api.registerRequestInterceptor(function (config) {
+    assert.strictEqual(config.headers['x-sync'], 'ok');
+    return Promise.resolve({
+      headers: {
+        'x-async': 'ignored'
+      }
+    });
+  });
+
+  const requestConfig = api.applyRequestInterceptors({
+    url: '/pets',
+    headers: {
+      'x-sync': 'ok'
+    }
+  }, {
+    requestType: 'form'
+  });
+
+  assert.strictEqual(requestConfig.headers['x-sync'], 'ok');
+  assert.strictEqual(requestConfig.headers['x-async'], undefined);
+  assert.strictEqual(typeof requestConfig.then, 'undefined');
+  assert.strictEqual(warnMessages.length, 1);
+}
+
+async function testScriptLoading() {
+  const appended = [];
+  const document = {
+    createElement: function (tagName) {
+      assert.strictEqual(tagName, 'script');
+      return {};
+    },
+    head: {
+      appendChild: function (script) {
+        appended.push(script.src);
+        setImmediate(script.onload);
+      }
+    }
+  };
+  const api = extension.createKnife4jExtension({ document });
+
+  await api.loadCustomScripts([
+    '',
+    '/knife4j/custom/a.js',
+    '/knife4j/custom/b.js',
+    '/knife4j/custom/a.js'
+  ]);
+
+  assert.deepStrictEqual(appended, [
+    '/knife4j/custom/a.js',
+    '/knife4j/custom/b.js'
+  ]);
+}
+
+async function main() {
+  assert.strictEqual(path.basename(__filename), 'custom-script-extension.test.cjs');
+  await testRequestInterceptors();
+  await testPromiseInterceptorIsIgnored();
+  await testScriptLoading();
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add backend `customJavaScriptUrls` setting support for Knife4j doc.html extension scripts.
- Load configured scripts in Vue2/Vue3 doc initialization and expose `window.Knife4j.registerRequestInterceptor` for debug request customization.
- Apply request interceptors to url-form, form, and raw debug requests so injected headers are sent and reflected in curl output.
- Document usage, security notes, and the difference from AfterScript.
- Add Spring configuration binding tests for OpenAPI2 and OpenAPI3 Jakarta starters.

## Test Plan
- `node tests/custom-script-extension.test.cjs`
- `mvn -pl knife4j-openapi2-spring-boot-starter,knife4j-openapi3-jakarta-spring-boot-starter -am -Dknife4j-skipTests=false "-Dspotless.apply.skip=true" test`
- `mvn -pl knife4j-core,knife4j-openapi2-spring-boot-starter,knife4j-openapi3-spring-boot-starter,knife4j-openapi3-jakarta-spring-boot-starter -am -DskipTests "-Dspotless.apply.skip=true" compile`